### PR TITLE
Added Projects Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ cd cscc09.com
    - Replace `<Your Project Name>` with your project title
    - Replace `<Your Description>` with a brief description (max 150 characters for the card view)
    - Update the `groupMembers` list with your team members' names
+   - Replace `<Your YouTube Presentation Link>` with your final presentation video URL
    - Write a detailed description in the markdown section below the frontmatter
 
 ### File Naming Requirements
@@ -98,6 +99,7 @@ groupMembers:
   - Alice Johnson
   - Bob Smith
   - Carol Davis
+youtubeLink: https://www.youtube.com/watch?v=your-video-id
 ---
 
 Here you can write a longer description about your project. You can include [links](https://github.com/your-repo) to your GitHub repositories or live deployed versions of your project.
@@ -131,7 +133,7 @@ Here you can write a longer description about your project. You can include [lin
 
 ```shell
 git add src/content/projects/your-project-name.md
-git commit -m "feat: added project <your project name> to projects page</your>"
+git commit -m "feat: added project <your project name> to projects page"
 git push origin main
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,147 @@ Prerequisites: Node 18+ and Yarn 1.22+ installed.
 3.  **Open the code and start customizing!**
 
     Your site is now running at http://localhost:5173!
+
+## 📝 Contributing Your Project
+
+Want to showcase your project on this site? Follow these steps to add your project to the collection!
+
+### Step 1: Fork the Repository
+
+1. Go to the [CSCC09 website repository](https://github.com/your-username/cscc09.com)
+2. Click the "Fork" button in the top right corner
+3. This creates a copy of the repository under your GitHub account
+
+### Step 2: Clone Your Fork
+
+```shell
+git clone https://github.com/YOUR_USERNAME/cscc09.com.git
+cd cscc09.com
+```
+
+### Step 3: Create Your Project File
+
+1. **Navigate to the projects directory:**
+
+   ```shell
+   cd src/content/projects
+   ```
+
+   > **Note:** If this directory doesn't exist (you're the first group to contribute), create it:
+
+   ```shell
+   mkdir -p src/content/projects
+   ```
+
+2. **Copy the project template:**
+
+   ```shell
+   cp ../../../templates/project-template.md your-project-name.md
+   ```
+
+3. **Edit your project file:**
+   - Replace `<Your Group's Name>` with your actual group name
+   - Replace `<Your Project Name>` with your project title
+   - Replace `<Your Description>` with a brief description (max 150 characters for the card view)
+   - Update the `groupMembers` list with your team members' names
+   - Write a detailed description in the markdown section below the frontmatter
+
+### File Naming Requirements
+
+**Important:** The filename you choose will become the URL slug for your project page. For example:
+
+- `my-awesome-app.md` → URL: `/projects/my-awesome-app`
+
+**Best practices:**
+
+- Use descriptive, lowercase names
+- Separate words with hyphens
+- Keep it concise but meaningful
+- Avoid numbers and other special characters
+
+### Step 4: Project File Structure
+
+Your project file should look like this:
+
+```markdown
+---
+groupName: Team Awesome
+title: My Amazing Web App
+description: A responsive web application built with modern technologies
+groupMembers:
+  - Alice Johnson
+  - Bob Smith
+  - Carol Davis
+---
+
+Here you can write a longer description about your project. You can include [links](https://github.com/your-repo) to your GitHub repositories or live deployed versions of your project.
+
+## Features
+
+- Feature 1
+- Feature 2
+- Feature 3
+
+## Technologies Used
+
+- HTML5
+- CSS3
+- JavaScript
+```
+
+### Step 5: Test Your Changes
+
+1. **Start the development server:**
+
+   ```shell
+   yarn dev
+   ```
+
+2. **Navigate to the projects page** at `http://localhost:5173/projects`
+3. **Check that your project appears** in the grid
+4. **Click on your project** to verify the individual page displays correctly
+
+### Step 6: Commit and Push
+
+```shell
+git add src/content/projects/your-project-name.md
+git commit -m "feat: added project <your project name> to projects page</your>"
+git push origin main
+```
+
+### Step 7: Create a Pull Request
+
+1. Go to your forked repository on GitHub
+2. Click "Compare & pull request"
+3. **Write a descriptive title** like "Add project: [Your Project Name]"
+4. **Add a description** explaining your project:
+
+   ```
+   ## Project Description
+   Brief description of what your project does
+
+   ## Team Members
+   - Alice Johnson
+   - Bob Smith
+   - Carol Davis
+
+   ## Technologies Used
+   - HTML5, CSS3, JavaScript
+   - Any other relevant technologies
+   ```
+
+5. Click "Create pull request"
+
+### Step 8: Wait for Review
+
+Your pull request will be reviewed and merged if everything looks good! Once merged, your project will appear on the live site.
+
+## 📋 Project Guidelines
+
+- **Keep descriptions concise** - The card view shows max 150 characters
+- **Include all team members** - Make sure everyone gets credit
+- **Add relevant links** - GitHub repos, live demos, etc.
+- **Use clear, descriptive titles** - Make it easy to understand what your project does
+- **Test your changes locally** - Make sure everything works before submitting
+
+Happy contributing! 🎉

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -208,6 +208,10 @@ export class AppComponent {
       path: "/resources",
     },
     {
+      name: "Projects",
+      path: "/projects",
+    },
+    {
       name: "Team",
       path: "/team",
     },

--- a/src/app/interfaces/file-attributes.ts
+++ b/src/app/interfaces/file-attributes.ts
@@ -21,4 +21,5 @@ export interface CourseworkAttributes extends FileAttributes {
 export interface ProjectAttributes extends FileAttributes {
   groupName: string;
   groupMembers: string[];
+  youtubeLink?: string;
 }

--- a/src/app/interfaces/file-attributes.ts
+++ b/src/app/interfaces/file-attributes.ts
@@ -17,3 +17,8 @@ export interface CourseworkAttributes extends FileAttributes {
   dueDate: Date;
   pin: boolean;
 }
+
+export interface ProjectAttributes extends FileAttributes {
+  groupName: string;
+  groupMembers: string[];
+}

--- a/src/app/pages/projects.[projectId].page.ts
+++ b/src/app/pages/projects.[projectId].page.ts
@@ -118,6 +118,40 @@ import { getMeta } from "../meta/route-meta";
         margin-bottom: 0.5em;
       }
 
+      .project-video {
+        margin: 2em 0;
+      }
+
+      .video-title {
+        font-size: 16px;
+        font-weight: 600;
+        color: #f8fafc;
+        margin-bottom: 1em;
+        display: flex;
+        align-items: center;
+        gap: 0.5em;
+      }
+
+      .video-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5em;
+        color: #90cdf4;
+        text-decoration: none;
+        padding: 0.5em 1em;
+        background: rgba(66, 153, 225, 0.1);
+        border: 1px solid rgba(66, 153, 225, 0.2);
+        border-radius: 6px;
+        transition: all 0.2s ease;
+        font-size: 14px;
+      }
+
+      .video-link:hover {
+        background: rgba(66, 153, 225, 0.2);
+        border-color: rgba(66, 153, 225, 0.3);
+        transform: translateY(-1px);
+      }
+
       @media (max-width: 768px) {
         .container {
           padding: 0 0.5em;
@@ -156,6 +190,18 @@ import { getMeta } from "../meta/route-meta";
                 <span class="member-tag">{{ member }}</span>
               }
             </div>
+          </div>
+        }
+        @if (project.attributes.youtubeLink) {
+          <div class="project-video">
+            <div class="video-title">Final Presentation Video</div>
+            <a
+              [href]="project.attributes.youtubeLink"
+              target="_blank"
+              class="video-link"
+            >
+              Watch on YouTube
+            </a>
           </div>
         }
         <div class="project-content">

--- a/src/app/pages/projects.[projectId].page.ts
+++ b/src/app/pages/projects.[projectId].page.ts
@@ -1,0 +1,193 @@
+import {
+  ContentFile,
+  MarkdownComponent,
+  injectContent,
+} from "@analogjs/content";
+import { Component, inject } from "@angular/core";
+import { ProjectAttributes } from "../interfaces/file-attributes";
+import { Meta, Title } from "@angular/platform-browser";
+import { getMeta } from "../meta/route-meta";
+
+@Component({
+  standalone: true,
+  imports: [MarkdownComponent],
+  styles: [
+    `
+      .container {
+        margin-top: 3em;
+        max-width: 800px;
+        margin-left: auto;
+        margin-right: auto;
+        padding: 0 1em;
+      }
+
+      h1 {
+        font-size: 2.5em;
+        font-weight: 700;
+        margin-bottom: 0.5em;
+        color: #f8fafc;
+        line-height: 1.2;
+      }
+
+      .project-header {
+        padding: 2em;
+        padding-bottom: 0;
+      }
+
+      .project-group {
+        font-size: 12px;
+        background-color: rgba(66, 153, 225, 0.2);
+        color: #90cdf4;
+        padding: 4px 12px;
+        border-radius: 6px;
+        display: inline-block;
+        margin-bottom: 1em;
+        font-weight: 600;
+        letter-spacing: 0.5px;
+      }
+
+      .project-description {
+        font-size: 18px;
+        color: #a0aec0;
+        margin: 1.5em 0;
+        line-height: 1.6;
+        font-weight: 400;
+      }
+
+      .project-members {
+        margin-top: 2em;
+        padding-top: 1em;
+        border-top: 1px solid rgba(226, 232, 240, 0.16);
+      }
+
+      .members-title {
+        font-size: 14px;
+        font-weight: 600;
+        color: #f8fafc;
+        margin-bottom: 1em;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .members-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75em;
+      }
+
+      .member-tag {
+        font-size: 13px;
+        background-color: rgba(226, 232, 240, 0.08);
+        color: #a0aec0;
+        padding: 6px 12px;
+        border-radius: 6px;
+        border: 1px solid rgba(226, 232, 240, 0.16);
+        font-weight: 500;
+      }
+
+      .project-content {
+        margin-top: 2em;
+        line-height: 1.7;
+      }
+
+      .project-content h2 {
+        font-size: 1.5em;
+        font-weight: 600;
+        color: #f8fafc;
+        margin: 1.5em 0 0.5em 0;
+      }
+
+      .project-content h3 {
+        font-size: 1.25em;
+        font-weight: 600;
+        color: #e2e8f0;
+        margin: 1.25em 0 0.5em 0;
+      }
+
+      .project-content p {
+        color: #a0aec0;
+        margin-bottom: 1em;
+      }
+
+      .project-content ul {
+        color: #a0aec0;
+        margin-bottom: 1em;
+      }
+
+      .project-content li {
+        margin-bottom: 0.5em;
+      }
+
+      @media (max-width: 768px) {
+        .container {
+          padding: 0 0.5em;
+        }
+
+        h1 {
+          font-size: 2em;
+        }
+
+        .project-header {
+          padding: 1.5em;
+        }
+      }
+    `,
+  ],
+  template: `
+    <div class="container">
+      @if (project) {
+        <div class="project-header">
+          <h1>{{ project.attributes.title }}</h1>
+          <div class="project-group">
+            {{ project.attributes.groupName }}
+          </div>
+          <div class="project-description">
+            {{ project.attributes.description }}
+          </div>
+        </div>
+        @if (
+          project.attributes.groupMembers &&
+          project.attributes.groupMembers.length > 0
+        ) {
+          <div class="project-members">
+            <div class="members-title">Team Members</div>
+            <div class="members-list">
+              @for (member of project.attributes.groupMembers; track member) {
+                <span class="member-tag">{{ member }}</span>
+              }
+            </div>
+          </div>
+        }
+        <div class="project-content">
+          <analog-markdown [content]="project.content"></analog-markdown>
+        </div>
+      }
+    </div>
+  `,
+  providers: [Meta],
+})
+export default class ProjectComponent {
+  meta = inject(Meta);
+  title = inject(Title);
+  project: ContentFile<ProjectAttributes | Record<string, never>> | undefined =
+    undefined;
+
+  constructor() {
+    injectContent<ProjectAttributes>({
+      param: "projectId",
+      subdirectory: "projects",
+    }).subscribe((project) => {
+      this.setProject(project as ContentFile<ProjectAttributes>);
+    });
+  }
+
+  setProject(project: ContentFile<ProjectAttributes>) {
+    this.project = project;
+    this.title.setTitle(project.attributes.title);
+    const meta = getMeta({
+      title: project.attributes.title,
+      description: project.attributes.description,
+    });
+    meta.forEach((tag) => this.meta.updateTag(tag));
+  }
+}

--- a/src/app/pages/projects.page.ts
+++ b/src/app/pages/projects.page.ts
@@ -1,0 +1,203 @@
+import { injectContentFiles } from "@analogjs/content";
+import { Component, Input } from "@angular/core";
+import { ProjectAttributes } from "../interfaces/file-attributes";
+
+import { RouterLink } from "@angular/router";
+import { RouteMeta } from "@analogjs/router";
+import { getRouteMeta } from "../meta/route-meta";
+import { environment } from "../../environments/environment";
+
+export const routeMeta: RouteMeta = getRouteMeta({
+  partialTitle: "Projects",
+  description: `Previous projects completed by students who have taken ${environment.courseCode} in the past.`,
+});
+
+@Component({
+  standalone: true,
+  imports: [RouterLink],
+  selector: "app-project-item",
+  styles: [
+    `
+      .project-card {
+        background: rgba(226, 232, 240, 0.04);
+        border: 1px solid rgba(226, 232, 240, 0.12);
+        border-radius: 8px;
+        padding: 1.5em;
+        text-decoration: none;
+        color: inherit;
+        transition: all 0.2s ease;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .project-card:hover {
+        background: rgba(226, 232, 240, 0.08);
+        border-color: rgba(226, 232, 240, 0.2);
+        transform: translateY(-1px);
+      }
+
+      .project-title {
+        font-size: 1.25em;
+        font-weight: 600;
+        margin-bottom: 0.5em;
+        color: #f8fafc;
+        line-height: 1.3;
+      }
+
+      .project-group-name {
+        font-size: 11px;
+        background-color: rgba(66, 153, 225, 0.2);
+        color: #90cdf4;
+        padding: 3px 8px;
+        border-radius: 4px;
+        display: inline-block;
+        margin-bottom: 1em;
+        align-self: flex-start;
+        font-weight: 500;
+        letter-spacing: 0.5px;
+      }
+
+      .project-description {
+        font-size: 14px;
+        color: #a0aec0;
+        line-height: 1.5;
+        margin-bottom: 1em;
+      }
+
+      .project-members {
+        margin-top: auto;
+        padding-top: 1em;
+        border-top: 1px solid rgba(226, 232, 240, 0.08);
+      }
+
+      .members-label {
+        font-size: 10px;
+        color: #718096;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.5em;
+        font-weight: 500;
+      }
+
+      .members-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4em;
+      }
+
+      .member-tag {
+        font-size: 10px;
+        background-color: rgba(226, 232, 240, 0.08);
+        color: #a0aec0;
+        padding: 2px 6px;
+        border-radius: 3px;
+        border: 1px solid rgba(226, 232, 240, 0.12);
+        font-weight: 400;
+      }
+    `,
+  ],
+  template: `
+    @if (project) {
+      <a [routerLink]="'/projects/' + slug" class="project-card">
+        <div class="project-group-name">
+          {{ project.groupName }}
+        </div>
+        <div class="project-title">{{ project.title }}</div>
+        <div class="project-description">
+          {{ truncateDescription(project.description) }}
+        </div>
+        @if (project.groupMembers && project.groupMembers.length > 0) {
+          <div class="project-members">
+            <div class="members-label">Team Members</div>
+            <div class="members-list">
+              @for (member of project.groupMembers; track member) {
+                <span class="member-tag">{{ member }}</span>
+              }
+            </div>
+          </div>
+        }
+      </a>
+    }
+  `,
+})
+export class ProjectItemComponent {
+  @Input() project?: ProjectAttributes;
+  @Input() slug?: string;
+  @Input() descriptionLimit: number = 150;
+
+  truncateDescription(description: string): string {
+    if (description.length <= this.descriptionLimit) {
+      return description;
+    }
+    return description.substring(0, this.descriptionLimit).trim() + "...";
+  }
+}
+
+@Component({
+  standalone: true,
+  imports: [ProjectItemComponent],
+  styles: [
+    `
+      .projects-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 0 1em;
+      }
+
+      .projects-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 2em;
+        margin-top: 2em;
+      }
+
+      @media (max-width: 768px) {
+        .projects-grid {
+          grid-template-columns: 1fr;
+          gap: 1.5em;
+        }
+      }
+
+      @media (max-width: 480px) {
+        .container {
+          padding: 0 0.5em;
+        }
+
+        .projects-grid {
+          gap: 1em;
+        }
+      }
+    `,
+  ],
+  template: `
+    <div class="container">
+      <header>
+        <h1>Previous Projects</h1>
+        <p>
+          This page is a collection of projects that have been completed by
+          students in the past. If you want your project featured on this page,
+          please head to the GitHub repository for the site and submit a pull
+          request following the guidelines in the README.md.
+        </p>
+      </header>
+      <div class="projects-container">
+        <div class="projects-grid">
+          @for (project of projects; track project) {
+            <app-project-item
+              [slug]="project.slug"
+              [project]="project.attributes"
+            ></app-project-item>
+          }
+        </div>
+      </div>
+    </div>
+  `,
+})
+export default class ProjectsPage {
+  readonly projects = injectContentFiles<ProjectAttributes>((contentFile) =>
+    contentFile.filename.includes("/src/content/projects/"),
+  );
+}

--- a/src/content/projects/your-portfolio.md
+++ b/src/content/projects/your-portfolio.md
@@ -1,0 +1,20 @@
+---
+groupName: Wenduo Sky Chop Chop
+title: YourPortfolio
+description: YourPortfolio is a professional AI-powered resume and cover letter creator.
+groupMembers:
+  - Jason Su
+  - Miles Bernstein
+youtubeLink: https://www.youtube.com/watch?v=3N4g8nXutdE
+---
+
+YourPortfolio is an AI-powered resume and cover letter generator that helps job seekers create tailored application materials quickly and professionally. The application integrates with job search functionality to streamline the entire job application process.
+
+## Key Features
+
+- AI-powered resume and cover letter generation using Google Gemini API
+- Job search portal with Indeed job postings integration
+- Multiple resume and cover letter format options
+- User profile management for skills, experience, and interests
+- Google OAuth 2.0 authentication
+- Credit system with Stripe payment integration

--- a/src/content/projects/your-portfolio.md
+++ b/src/content/projects/your-portfolio.md
@@ -18,3 +18,12 @@ YourPortfolio is an AI-powered resume and cover letter generator that helps job 
 - User profile management for skills, experience, and interests
 - Google OAuth 2.0 authentication
 - Credit system with Stripe payment integration
+
+## Technical Implementation
+
+- **Frontend**: Angular
+- **Backend**: ExpressJS
+- **Database**: PostgreSQL hosted on Google Cloud
+- **AI Integration**: Google Gemini API
+- **Authentication**: OAuth 2.0 with Google accounts
+- **Payment Processing**: Stripe

--- a/templates/project-template.md
+++ b/templates/project-template.md
@@ -1,0 +1,12 @@
+---
+groupName: <Your Group's Name>
+title: <Your Project Name>
+description: <Your Description>
+groupMembers:
+  - John Doe
+  - Jane Doe
+---
+
+Here you can write a longer description about your project. You can include [links](https://www.google.com) to your GitHub repositories or live deployed versions of your project. Make sure the links are up so students can access them in the future!
+
+This section is written in markdown and will be rendered on your project's own page on the site. Markdown syntax is supported like headings, lists, etc.

--- a/templates/project-template.md
+++ b/templates/project-template.md
@@ -5,6 +5,7 @@ description: <Your Description>
 groupMembers:
   - John Doe
   - Jane Doe
+youtubeLink: <Your YouTube Presentation Link>
 ---
 
 Here you can write a longer description about your project. You can include [links](https://www.google.com) to your GitHub repositories or live deployed versions of your project. Make sure the links are up so students can access them in the future!


### PR DESCRIPTION
# Add Projects Showcase Feature

## Overview

I've added a page for students to showcase their projects on the site. Students can create pull requests with their added project markdown files according to the instructions written in the `README.md` file in the repository. These projects will show up in a grid layout on the /projects page and each project will have their own page where students can write longer descriptions of their project and include relevant links.

## Feature Breakdown

### Projects Grid Page (`/projects`)
- **Responsive grid layout** with project information displayed in cards
- **Project cards** displaying title, group name, description, and team members
- **Truncated descriptions** (150 character limit) for consistent card heights
- **Mobile-responsive** design that adapts to different screen sizes

### Individual Project Pages (`/projects/[projectId]`)
- Displays markdown that students can customize in their individual project markdown files.

## Screenshots

### Projects Grid Page
<img width="1910" height="926" alt="image" src="https://github.com/user-attachments/assets/eec09d4c-561a-461e-bb34-445b5b070d79" />

*Responsive grid layout showing project cards with team members*

### Individual Project Page
<img width="1902" height="926" alt="image" src="https://github.com/user-attachments/assets/82ad9624-cffa-4fa9-803b-0a15299c049c" />

*Detailed project view with full description and team information*

### Mobile Responsive View
<img width="522" height="924" alt="image" src="https://github.com/user-attachments/assets/07a3d69e-3800-430b-a639-afdf93d70526" />

*Mobile-optimized layout with single column grid*

## Documentation

### For Students
- **Comprehensive README section** with step-by-step contribution guide
- **Project template** with all required fields